### PR TITLE
fix: HubSpot API送信時のプロパティ不一致を修正

### DIFF
--- a/app/_actions/contact.tsx
+++ b/app/_actions/contact.tsx
@@ -1,16 +1,25 @@
 "use server";
 
+type FormState = {
+  status: "success" | "error" | "";
+  message: string;
+};
+
 function validateEmail(email: string) {
   const pattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return pattern.test(email);
 }
 
-export async function createContactDate(_prevState: any, formData: FormData) {
+export async function createContactDate(
+  _prevState: FormState | null,
+  formData: FormData
+): Promise<FormState> {
   const rawFormDate = {
     name: formData.get("name") as string,
     company: formData.get("company") as string,
     email: formData.get("email") as string,
     message: formData.get("message") as string,
+    hutk: formData.get("hutk") as string,
   };
 
   if (!rawFormDate.name) {
@@ -38,6 +47,32 @@ export async function createContactDate(_prevState: any, formData: FormData) {
     };
   }
 
+  const payload = {
+    fields: [
+      {
+        name: "fullname",
+        value: rawFormDate.name,
+      },
+      {
+        name: "company",
+        value: rawFormDate.company,
+      },
+      {
+        name: "email",
+        value: rawFormDate.email,
+      },
+      {
+        name: "message",
+        value: rawFormDate.message,
+      },
+    ],
+    context: {
+      hutk: rawFormDate.hutk,
+      pageUri: process.env.NEXT_PUBLIC_SITE_URL + "/contact",
+      pageName: "Contact",
+    },
+  };
+
   const result = await fetch(
     `https://api.hsforms.com/submissions/v3/integration/submit/${process.env.HUBSPOT_PORTAL_ID}/${process.env.HUBSPOT_FORM_ID}`,
     {
@@ -45,26 +80,7 @@ export async function createContactDate(_prevState: any, formData: FormData) {
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({
-        fields: [
-          {
-            name: "fullname",
-            value: rawFormDate.name,
-          },
-          {
-            name: "company",
-            value: rawFormDate.company,
-          },
-          {
-            name: "email",
-            value: rawFormDate.email,
-          },
-          {
-            name: "message",
-            value: rawFormDate.message,
-          },
-        ],
-      }),
+      body: JSON.stringify(payload),
     }
   );
 

--- a/app/_actions/contact.tsx
+++ b/app/_actions/contact.tsx
@@ -48,7 +48,7 @@ export async function createContactDate(_prevState: any, formData: FormData) {
       body: JSON.stringify({
         fields: [
           {
-            name: "name",
+            name: "fullname",
             value: rawFormDate.name,
           },
           {

--- a/app/components/ContactForm/index.module.css
+++ b/app/components/ContactForm/index.module.css
@@ -43,3 +43,8 @@
   gap: 20px;
   color: #ff191d;
 }
+.success {
+  padding: 20px;
+  background: var(--color-gray);
+  text-align: center;
+}

--- a/app/components/ContactForm/index.tsx
+++ b/app/components/ContactForm/index.tsx
@@ -1,16 +1,21 @@
 "use client";
 
 import { createContactDate } from "@/app/_actions/contact";
-import { useFormState } from "react-dom";
+import { useActionState } from "react";
 import styles from "./index.module.css";
 
-const initalState = {
+type FormState = {
+  status: "success" | "error" | "";
+  message: string;
+};
+
+const initialState: FormState = {
   status: "",
   message: "",
 };
 
 export default function ContactForm() {
-  const [state, formAction] = useFormState(createContactDate, initalState);
+  const [state, formAction] = useActionState(createContactDate, initialState);
   console.log(state);
   if (state.status === "success") {
     return (
@@ -23,6 +28,18 @@ export default function ContactForm() {
   }
   return (
     <form className={styles.form} action={formAction}>
+      <input
+        type="hidden"
+        name="hutk"
+        value={
+          typeof document !== "undefined"
+            ? document.cookie
+                .split("; ")
+                .find((row) => row.startsWith("hubspotutk="))
+                ?.split("=")[1] ?? ""
+            : ""
+        }
+      />
       <div className={styles.item}>
         <label className={styles.label} htmlFor="name">
           お名前 <span className={styles.required}>*</span>

--- a/app/contact/layout.tsx
+++ b/app/contact/layout.tsx
@@ -1,0 +1,24 @@
+import Script from "next/script";
+
+export default function ContactLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <>
+      {/* HubSpot Tracking Script */}
+      {/* 
+        HubSpot tracking script
+        - Contactページ限定
+        - hubspotutk を取得するため
+        */}
+      <Script
+        id="hubspot-tracking"
+        strategy="afterInteractive"
+        src={`https://js.hs-scripts.com/${process.env.NEXT_PUBLIC_HUBSPOT_PORTAL_ID}.js`}
+      />
+      {children}
+    </>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="ja">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         {children}
       </body>


### PR DESCRIPTION
## 概要
お問い合わせフォームからHubSpotへデータ送信時に、
正しいプロパティ名が設定されておらず通信に失敗していたため修正しました。

## 修正内容
- HubSpotコンタクトのプロパティ名を正しい内部名に修正
  - name → name / fullname
- 送信成功／失敗時の挙動を確認

## 確認方法
1. お問い合わせフォームから送信
2. HubSpotのコンタクトにレコードが作成されることを確認