### PR TITLE
fix: ニュースページのSP表示調整

### DIFF
--- a/app/news/page.module.css
+++ b/app/news/page.module.css
@@ -61,4 +61,15 @@
   .news_list {
     padding: 50px;
   }
+
+  .news_category {
+    gap: 0 !important;
+    flex-direction: column;
+  }
+
+  .news_image {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## 概要
スマホ表示時のニュースページのレイアウトを調整しました。

## 変更内容
- カテゴリータグの表示調整
- イメージの中央配置

## 確認方法
PCブラウザでスマホ表示に切り替える
ニュースページを開き、表示崩れや余白が適切か確認