### PR TITLE
fix: メタデータのパスの修正

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
     siteName: "Visionary Mate",
     images: [
       {
-        url: "/images/ogp.png",
+        url: "/image/ogp.png",
         width: 1200,
         height: 630,
         alt: "Visionary Mate OGP",
@@ -43,9 +43,7 @@ export const metadata: Metadata = {
     title: "Visionary Mate",
     description:
       "デザイナー兼エンジニアとして、WEBサイト開発やアプリ開発を行っています。",
-    images: [
-      "https://visionary-mate.vercel.app/images/summary_large_image.png",
-    ],
+    images: ["https://visionary-mate.vercel.app/image/ogp.png"],
   },
   alternates: {
     canonical: "https://visionary-mate.vercel.app",


### PR DESCRIPTION
## 概要
メタデータで指定していたパスが誤っていたため修正しました。

## 変更内容
- OGP画像・メタデータ関連のパスを正しいものに修正
- 本番環境でも正しくメタデータが解釈されるように対応

## 影響範囲
- SEO / OGP表示周りのみ
