### PR TITLE
Fix: Tailwind CSS適用

### DIFF
--- a/app/aboutme/page.tsx
+++ b/app/aboutme/page.tsx
@@ -26,7 +26,9 @@ export default function page() {
           <div></div>
 
           <div className={styles.skills}>
-            <h3 className={barlowCondensed.className}>Skill</h3>
+            <h3 className={`text-[50px]! ${barlowCondensed.className}`}>
+              Skill
+            </h3>
             <dl className={styles.skill_section}>
               <dt className={barlowCondensed.className}>Design</dt>
               <dd>

--- a/app/components/ContactForm/index.module.css
+++ b/app/components/ContactForm/index.module.css
@@ -10,11 +10,15 @@
 }
 
 .textfield {
-  padding: 5px;
+  padding: 5px 10px;
+  border-width: 1px;
+  border-radius: 5px;
 }
 
 .textarea {
-  padding: 5px;
+  padding: 5px 10px;
+  border-width: 1px;
+  border-radius: 5px;
 }
 
 .required {

--- a/app/components/ContactForm/index.tsx
+++ b/app/components/ContactForm/index.tsx
@@ -55,6 +55,8 @@ export default function ContactForm() {
           type="text"
           id="name"
           name="name"
+          autoComplete="name"
+          placeholder="田中太郎"
           required
         />
       </div>
@@ -67,6 +69,7 @@ export default function ContactForm() {
           className={styles.textfield}
           type="text"
           id="company"
+          autoComplete="company"
           name="company"
         />
       </div>
@@ -80,6 +83,8 @@ export default function ContactForm() {
           type="text"
           id="email"
           name="email"
+          autoComplete="email"
+          placeholder="example@example.com"
           required
         />
       </div>
@@ -92,6 +97,8 @@ export default function ContactForm() {
           className={styles.textarea}
           id="message"
           name="message"
+          autoComplete="message"
+          placeholder="お問い合わせ内容をご記入ください。"
           required
         />
       </div>

--- a/app/components/NewsList/index.module.css
+++ b/app/components/NewsList/index.module.css
@@ -32,11 +32,6 @@
   margin-top: 5px;
 }
 
-.news_wrapper dd > span {
-  display: flex;
-  gap: 15px;
-}
-
 .news_category {
   color: black;
 }
@@ -58,10 +53,5 @@
 
   .news_image {
     width: 100%;
-  }
-
-  .news_wrapper dd > span {
-    flex-direction: column;
-    gap: 0px;
   }
 }

--- a/app/components/NewsList/index.tsx
+++ b/app/components/NewsList/index.tsx
@@ -42,7 +42,7 @@ export default async function NewsList({ news }: Props) {
                   <h3>{article.title}</h3>
                 </dt>
                 <dd>
-                  <span className={styles.news_category}>
+                  <span className={`flex flex-wrap gap-x-[15px] gap-y-0 ${styles.news_category}`}>
                     <Category categories={article.categories} />
                   </span>
                 </dd>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,14 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
+
+@layer base {
+  h1, h2, h3, h4, h5, h6, strong {
+    font-weight: bold;
+  }
+}
+
+h3 {
+  font-size: 18px !important;
+}
 
 :root {
   --background: #000000;

--- a/app/news/[slug]/page.module.css
+++ b/app/news/[slug]/page.module.css
@@ -33,7 +33,6 @@
 
 .news_category {
   display: flex;
-  gap: 15px;
 }
 
 .body {

--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -55,7 +55,7 @@ export default async function Page({ params }: Props) {
               )}
             </div>
             <h1 className={styles.title}>{article.title}</h1>
-            <span className={styles.news_category}>
+            <span className={`flex-wrap gap-x-[15px] gap-y-0! ${styles.news_category}`}>
               <Category categories={article.categories} />
             </span>
             <p>

--- a/app/news/page.module.css
+++ b/app/news/page.module.css
@@ -47,7 +47,6 @@
 
 .news_wrapper dd > span {
   display: flex;
-  gap: 15px;
 }
 
 @media screen and (max-width: 767px) {
@@ -60,11 +59,6 @@
 
   .news_list {
     padding: 50px;
-  }
-
-  .news_category {
-    gap: 0 !important;
-    flex-direction: column;
   }
 
   .news_image {

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -61,7 +61,9 @@ export default async function Page() {
                       <h3>{article.title}</h3>
                     </dt>
                     <dd>
-                      <span className={`flex-wrap items-start md:items-center! gap-x-[15px] gap-y-0 ${styles.news_category}`}>
+                      <span
+                        className={`flex-wrap items-start md:items-center! gap-x-3.75 gap-y-0 ${styles.news_category}`}
+                      >
                         <Category categories={article.categories} />
                       </span>
                     </dd>

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -61,7 +61,7 @@ export default async function Page() {
                       <h3>{article.title}</h3>
                     </dt>
                     <dd>
-                      <span className={styles.news_category}>
+                      <span className={`flex-wrap items-start md:items-center! gap-x-[15px] gap-y-0 ${styles.news_category}`}>
                         <Category categories={article.categories} />
                       </span>
                     </dd>

--- a/app/service/page.tsx
+++ b/app/service/page.tsx
@@ -27,13 +27,13 @@ export default function page() {
               <li className={styles.service_item}>
                 <div className={styles["service__item-image"]}>
                   <Image
-                    className={styles.image}
+                    className={`md:max-w-none ${styles.image}`}
                     src="/image/HPLP.png"
                     alt="HP/LP制作"
                     width={300}
                     height={200}
                   />
-                  <p>HP/LP/アプリ制作</p>
+                  <p className="mt-2.5!">HP/LP/アプリ制作</p>
                 </div>
                 <div className={styles["service__item-text"]}>
                   <p>
@@ -45,13 +45,13 @@ export default function page() {
               <li className={styles.service_item}>
                 <div className={styles["service__item-image"]}>
                   <Image
-                    className={styles.image}
+                    className={`md:max-w-none ${styles.image}`}
                     src="/image/Banner.png"
                     alt="バナー制作"
                     width={300}
                     height={200}
                   />
-                  <p>バナー制作</p>
+                  <p className="mt-2.5!">バナー制作</p>
                 </div>
                 <div className={styles["service__item-text"]}>
                   <p>
@@ -62,13 +62,13 @@ export default function page() {
               <li className={styles.service_item}>
                 <div className={styles["service__item-image"]}>
                   <Image
-                    className={styles.image}
+                    className={`md:max-w-none ${styles.image}`}
                     src="/image/UIUX.png"
                     alt="UIUX改善"
                     width={300}
                     height={200}
                   />
-                  <p>UIUX改善</p>
+                  <p className="mt-2.5!">UIUX改善</p>
                 </div>
                 <div className={styles["service__item-text"]}>
                   <p>
@@ -80,13 +80,13 @@ export default function page() {
               <li className={styles.service_item}>
                 <div className={styles["service__item-image"]}>
                   <Image
-                    className={styles.image}
+                    className={`md:max-w-none ${styles.image}`}
                     src="/image/Maintenance.png"
                     alt="保守運用管理"
                     width={300}
                     height={200}
                   />
-                  <p>保守運用管理</p>
+                  <p className="mt-2.5!">保守運用管理</p>
                 </div>
                 <div className={styles["service__item-text"]}>
                   <p>

--- a/app/works/page.module.css
+++ b/app/works/page.module.css
@@ -57,11 +57,5 @@
       align-items: flex-start;
       flex-direction: column !important;
     }
-    .works_item {
-      width: 70vw;
-      .works_image {
-        width: 70vw;
-      }
-    }
   }
 }

--- a/app/works/page.module.css
+++ b/app/works/page.module.css
@@ -45,7 +45,7 @@
 }
 
 .works__item-detail {
-  margin: 0 5%;
+  margin: 0 4%;
 }
 
 /* スマホ用 */

--- a/app/works/page.tsx
+++ b/app/works/page.tsx
@@ -28,7 +28,7 @@ export default async function Page() {
           <ul className={styles.news_list}>
             {workList.contents.map((works) => (
               <li key={works.id} className={styles.works_item}>
-                <Link href={`/works/${works.id}`}>
+                <Link className="md:gap-12.5" href={`/works/${works.id}`}>
                   <div className={styles["works__item-images"]}>
                     <div className={styles.works_image}>
                       {works.workImage ? (
@@ -54,8 +54,8 @@ export default async function Page() {
                   </div>
                   <div className={styles["works__item-detail"]}>
                     <h3>{works.title}</h3>
-                    <h4>{works.subtitle}</h4>
-                    <p>{works.summary}</p>
+                    <h4 className="text-(--color-gray2)">{works.subtitle}</h4>
+                    <p className="mt-2.5!">{works.summary}</p>
                   </div>
                 </Link>
               </li>

--- a/app/works/page.tsx
+++ b/app/works/page.tsx
@@ -35,7 +35,7 @@ export default async function Page() {
                         <Image
                           src={works.workImage.url}
                           alt={works.title}
-                          className={styles.works_image}
+                          className={`md:max-w-none h-50 ${styles.works_image}`}
                           width={300}
                           height={200}
                           style={{ objectFit: "contain" }}
@@ -44,7 +44,7 @@ export default async function Page() {
                         <Image
                           src="/image/noimage.jpg"
                           alt="No Image"
-                          className={styles.works_image}
+                          className={`md:max-w-none h-50 ${styles.works_image}`}
                           width={300}
                           height={200}
                           style={{ objectFit: "contain" }}


### PR DESCRIPTION
概要
このプルリクエストでは、Tailwind CSSのユーティリティクラスを適用し、主に制作物一覧ページとニュース一覧ページのレスポンシブも含めてスタイルを修正しました。

変更点
* トップページ
* ニュースページ
* 制作物一覧ページ
* コンタクトページ 
